### PR TITLE
chore: add chore(deps) as patch release rule

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,11 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    ["@semantic-release/commit-analyzer", {
+      "releaseRules": [
+        {"type": "chore", "scope": "deps", "release": "patch"}
+      ]
+    }],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",


### PR DESCRIPTION
## Summary

- Add `releaseRules` to `@semantic-release/commit-analyzer` so that `chore(deps)` commits (e.g., Renovate lock file maintenance) trigger a patch release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to ensure dependency updates trigger appropriate patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->